### PR TITLE
Add last_run and current_set commands, migrated set updates

### DIFF
--- a/luke_bot/discord_bot.py
+++ b/luke_bot/discord_bot.py
@@ -5,7 +5,7 @@ from discord.ext import tasks, commands
 from discord.message import Message
 
 from .settings import settings
-from .smashgg_query import check_luke
+from .smashgg_query import check_luke, get_last_bracket_run, get_last_set
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,20 @@ class LukeCommands(commands.Cog):
         """Manually invoke an update, and have the bot post it to the channel where it was invoked"""
         embed = Embed()
         embed.description = str(check_luke())
+        await interaction.response.send_message(embed=embed)
+
+    @app_commands.command(name="last_run", description=f"Post {PLAYER_NAME}'s last bracket run results'")
+    async def last_run(self, interaction: Interaction):
+        text = get_last_bracket_run()
+        embed = Embed()
+        embed.description = text
+        await interaction.response.send_message(embed=embed)
+
+    @app_commands.command(name="current_set", description=f"Post {PLAYER_NAME}'s most recent ongoing set result'")
+    async def current_set(self, interaction: Interaction):
+        text = get_last_set()
+        embed = Embed()
+        embed.description = text
         await interaction.response.send_message(embed=embed)
 
 


### PR DESCRIPTION
As per issue #6, the set updates have instead been migrated to two related commands `last_run` and `current_set`

**EDIT - the set updates weren't actually removed from the "Upcoming" section in this commit

`last_run` - the bot replies with an embedded message containing the full bracket run of the player (Luke)
`current_set` - same as `last_run`, but omits the tournament name and only shows the most recent set result given by the Start.gg API